### PR TITLE
fix typo in module_link.rs

### DIFF
--- a/crates/wasi-vfs-cli/src/module_link.rs
+++ b/crates/wasi-vfs-cli/src/module_link.rs
@@ -1,4 +1,4 @@
-/// Given thse two modules:
+/// Given these two modules:
 ///
 /// libwasi_vfs.wasm
 /// ```webassembly


### PR DESCRIPTION
I fixed typo in `crates/wasi-vfs-cli/src/module_link.rs`.