### PR TITLE
C less mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,20 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
+ "cpp_demangle",
+ "fallible-iterator",
  "gimli",
+ "memmap2",
+ "object",
+ "rustc-demangle",
+ "smallvec",
 ]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -21,6 +33,15 @@ dependencies = [
  "once_cell",
  "version_check",
  "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -48,6 +69,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "arena-traits"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9124fa70d5ebbb2f2bef340dbaa0c5186a2df7ca66be5edd806f1e46383b6a09"
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +143,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -92,6 +168,12 @@ name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bincode"
@@ -223,6 +305,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg-traits"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c561f6cffa35f03f4dc575407362fa291e3c97028470e6814df022bbd4d294ef"
+dependencies = [
+ "arena-traits",
+ "either",
+]
+
+[[package]]
+name = "cfg-traits"
+version = "0.3.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d599ee7a04d8b5e63138bf0740dfe0f77cc7615f9dfb96fd569c3f0cedc3d6a6"
+dependencies = [
+ "arena-traits",
+ "either",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +338,12 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "core-foundation-sys"
@@ -430,6 +538,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
@@ -493,6 +612,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -512,6 +654,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ext-trait"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5"
+dependencies = [
+ "ext-trait-proc_macros",
+]
+
+[[package]]
+name = "ext-trait-proc_macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "extension-traits"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537"
+dependencies = [
+ "ext-trait",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +697,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -613,6 +794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +822,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -667,12 +860,12 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -697,6 +890,12 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -764,10 +963,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
-name = "libc"
-version = "0.2.155"
+name = "lending-iterator"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "bc07588c853b50689205fb5c00498aa681d89828e0ce8cbd965ebc7a5d8ae260"
+dependencies = [
+ "extension-traits",
+ "lending-iterator-proc_macros",
+ "macro_rules_attribute",
+ "never-say-never",
+ "nougat",
+ "polonius-the-crab",
+]
+
+[[package]]
+name = "lending-iterator-proc_macros"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5445dd1c0deb1e97b8a16561d17fc686ca83e8411128fb036e9668a72d51b1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
@@ -802,6 +1026,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +1063,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,15 +1087,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
+
+[[package]]
+name = "nougat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510"
+dependencies = [
+ "macro_rules_attribute",
+ "nougat-proc_macros",
+]
+
+[[package]]
+name = "nougat-proc_macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
+ "flate2",
  "hashbrown 0.14.3",
  "indexmap",
  "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -857,9 +1144,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -872,6 +1159,43 @@ name = "pkg-config"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+
+[[package]]
+name = "polonius-the-crab"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f"
+
+[[package]]
+name = "portal-pc-waffle"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a75b9b283b1bcdbfbae52157ade4265a6c8e04e3c0a9ff6df69a930fbef3cb"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "arena-traits",
+ "cfg-traits 0.2.1",
+ "cfg-traits 0.3.0-alpha.0",
+ "either",
+ "env_logger",
+ "fxhash",
+ "indexmap",
+ "lazy_static",
+ "lending-iterator",
+ "libc",
+ "log",
+ "paste",
+ "rayon",
+ "serde",
+ "smallvec",
+ "ssa-traits 0.2.1",
+ "ssa-traits 0.3.0-alpha.0",
+ "stacker",
+ "structopt",
+ "wasm-encoder 0.212.0",
+ "wasmparser 0.212.0",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -905,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1014,6 +1338,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1394,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
+dependencies = [
+ "byteorder",
+ "derive_more",
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,22 +1418,22 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1120,9 +1484,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sptr"
@@ -1131,10 +1495,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
+name = "ssa-traits"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b5d4195261ebb69852c6e5ea82688edbec5f8d4e177897a209014d273421fa"
+dependencies = [
+ "anyhow",
+ "arena-traits",
+ "cfg-traits 0.2.1",
+ "either",
+]
+
+[[package]]
+name = "ssa-traits"
+version = "0.3.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361fc58338790e74a8b5d46fa85605eb9d22933ffabece833c46f604e29803c3"
+dependencies = [
+ "anyhow",
+ "arena-traits",
+ "cfg-traits 0.3.0-alpha.0",
+ "either",
+ "lending-iterator",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799c883d55abdb5e98af1a7b3f23b9b6de8ecada0ecac058672d7635eb48ca7b"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "psm",
+ "windows-sys",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1179,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1236,7 +1644,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1293,7 +1701,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1303,6 +1711,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if 1.0.0",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1336,6 +1754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1776,27 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waffle-ast"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c808954a907c477bd254da0085434d7a64be889c8d0e03b27b970470277301a"
+dependencies = [
+ "anyhow",
+ "bimap",
+ "portal-pc-waffle",
+]
+
+[[package]]
+name = "waffle-unistub"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed96b472f2b6e4eb9046a593c9880c7dd0d1c7a4d2951a367041e2c3d974c3e"
+dependencies = [
+ "portal-pc-waffle",
+ "waffle-ast",
+]
 
 [[package]]
 name = "wasi"
@@ -1408,7 +1853,9 @@ name = "wasi-vfs-cli"
 version = "0.5.4"
 dependencies = [
  "anyhow",
+ "portal-pc-waffle",
  "structopt",
+ "waffle-unistub",
  "wasm-encoder 0.212.0",
  "wasmparser 0.212.0",
  "wizer",
@@ -1435,7 +1882,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
@@ -1457,7 +1904,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1625,7 +2072,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -1799,7 +2246,7 @@ checksum = "ffaafa5c12355b1a9ee068e9295d50c4ca0a400c721950cdae4f5b54391a2da5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1906,7 +2353,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn 2.0.48",
+ "syn 2.0.96",
  "witx 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1918,7 +2365,7 @@ checksum = "acdb12de36507498abaa3a042f895a43ee00a2f6125b6901b9a27edf72bfdbe7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
  "wiggle-generate",
 ]
 
@@ -2128,7 +2575,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["wasm"]
 keywords = ["webassembly", "wasm", "wasi"]
 
 [lib]
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["rlib", "staticlib", "cdylib"]
 
 [dependencies]
 wasi = "0.11.0"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ generate-trampoline:
 	$(TRAMPOLINE_GEN) object-link legacy > ./src/trampoline_generated_legacy_wasi_libc.c
 
 build:
-	cargo build --target wasm32-unknown-unknown
+	+WASI_VFS_C_MODE=1 cargo rustc --target wasm32-unknown-unknown --crate-type=staticlib
 
 check: build
 	env LIB_WASI_VFS_A=$(LIB_WASI_VFS_A) ./tools/run-make-test.sh

--- a/build.rs
+++ b/build.rs
@@ -1,30 +1,35 @@
 use std::env;
 
 fn main() {
-    let triple = env::var("TARGET").expect("TARGET was not set");
-    if !triple.starts_with("wasm32-") {
-        println!("wasi-vfs only supports wasm32-unknown-unknown");
-        return;
-    }
-    let wasi_sdk = env::var("WASI_SDK_PATH").expect("WASI_SDK_PATH is not set");
-    let mut build = cc::Build::new();
-    build
-        .compiler(format!("{}/bin/clang", wasi_sdk))
-        .archiver(format!("{}/bin/llvm-ar", wasi_sdk))
-        .file("src/init.c");
+    println!("cargo::rustc-check-cfg=cfg(cless)");
+    if env::var("WASI_VFS_C_MODE").is_ok() {
+        let triple = env::var("TARGET").expect("TARGET was not set");
+        if !triple.starts_with("wasm32-") {
+            println!("wasi-vfs only supports wasm32-unknown-unknown");
+            return;
+        }
+        let wasi_sdk = env::var("WASI_SDK_PATH").expect("WASI_SDK_PATH is not set");
+        let mut build = cc::Build::new();
+        build
+            .compiler(format!("{}/bin/clang", wasi_sdk))
+            .archiver(format!("{}/bin/llvm-ar", wasi_sdk))
+            .file("src/init.c");
 
-    let trampoline_file = if env::var("CARGO_FEATURE_LEGACY_WASI_LIBC").is_ok() {
-        "src/trampoline_generated_legacy_wasi_libc.c"
+        let trampoline_file = if env::var("CARGO_FEATURE_LEGACY_WASI_LIBC").is_ok() {
+            "src/trampoline_generated_legacy_wasi_libc.c"
+        } else {
+            "src/trampoline_generated.c"
+        };
+        build.file(trampoline_file);
+
+        println!("cargo:rerun-if-changed=src/init.c");
+        println!("cargo:rerun-if-changed={}", trampoline_file);
+
+        build.file("src/embed/linked_storage.c");
+        println!("cargo:rerun-if-changed=src/embed/linked_storage.c");
+
+        build.compile("wasi_vfs_c");
     } else {
-        "src/trampoline_generated.c"
-    };
-    build.file(trampoline_file);
-
-    println!("cargo:rerun-if-changed=src/init.c");
-    println!("cargo:rerun-if-changed={}", trampoline_file);
-
-    build.file("src/embed/linked_storage.c");
-    println!("cargo:rerun-if-changed=src/embed/linked_storage.c");
-
-    build.compile("wasi_vfs_c");
+        println!("cargo::rustc-cfg=cless")
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(cless)");
+    println!("cargo:rustc-check-cfg=cfg(cless)");
     if env::var("WASI_VFS_C_MODE").is_ok() {
         let triple = env::var("TARGET").expect("TARGET was not set");
         if !triple.starts_with("wasm32-") {
@@ -30,6 +30,8 @@ fn main() {
 
         build.compile("wasi_vfs_c");
     } else {
-        println!("cargo::rustc-cfg=cless")
+        println!("cargo:rustc-cfg=cless");
+        cc::Build::new().file("src/embed/linked_storage.c").compile("wasi_vfs_cless_c");
+        println!("cargo:rerun-if-changed=src/embed/linked_storage.c");
     }
 }

--- a/crates/wasi-libc-trampoline-bindgen/src/wrapper.rs
+++ b/crates/wasi-libc-trampoline-bindgen/src/wrapper.rs
@@ -161,6 +161,7 @@ impl Render for Module {
             render_trampoline(
                 &*f,
                 &format!("wasi_vfs_{}_{}", self.name.as_str(), f_name.to_snake_case()),
+                &format!("wasi_vfs.{}.{}",self.name.as_str(),f_name.to_snake_case()),
                 &self.name,
                 src,
             );
@@ -219,9 +220,9 @@ fn render_trace_syscall_entry_format_args(func: &InterfaceFunc, src: &mut String
     src.push(')');
 }
 
-fn render_trampoline(func: &InterfaceFunc, name: &str, module: &Id, src: &mut String) {
+fn render_trampoline(func: &InterfaceFunc, name: &str, cless_name: &str, module: &Id, src: &mut String) {
     src.push_str(" #[no_mangle]\n");
-    src.push_str(&format!("#[cfg_attr(cless,export_name(\"{name}\"))]\n"));
+    src.push_str(&format!("#[cfg_attr(cless,export_name(\"{cless_name}\"))]\n"));
     src.push_str("pub unsafe extern \"C\" fn ");
     src.push_str(name);
 

--- a/crates/wasi-libc-trampoline-bindgen/src/wrapper.rs
+++ b/crates/wasi-libc-trampoline-bindgen/src/wrapper.rs
@@ -222,7 +222,7 @@ fn render_trace_syscall_entry_format_args(func: &InterfaceFunc, src: &mut String
 
 fn render_trampoline(func: &InterfaceFunc, name: &str, cless_name: &str, module: &Id, src: &mut String) {
     src.push_str(" #[no_mangle]\n");
-    src.push_str(&format!("#[cfg_attr(cless,export_name(\"{cless_name}\"))]\n"));
+    src.push_str(&format!("#[cfg_attr(cless,export_name = \"{cless_name}\")]\n"));
     src.push_str("pub unsafe extern \"C\" fn ");
     src.push_str(name);
 

--- a/crates/wasi-libc-trampoline-bindgen/src/wrapper.rs
+++ b/crates/wasi-libc-trampoline-bindgen/src/wrapper.rs
@@ -221,6 +221,7 @@ fn render_trace_syscall_entry_format_args(func: &InterfaceFunc, src: &mut String
 
 fn render_trampoline(func: &InterfaceFunc, name: &str, module: &Id, src: &mut String) {
     src.push_str(" #[no_mangle]\n");
+    src.push_str(&format!("#[cfg_attr(cless,export_name(\"{name}\"))]\n"));
     src.push_str("pub unsafe extern \"C\" fn ");
     src.push_str(name);
 

--- a/crates/wasi-vfs-cli/Cargo.toml
+++ b/crates/wasi-vfs-cli/Cargo.toml
@@ -8,7 +8,9 @@ name = "wasi-vfs"
 
 [dependencies]
 anyhow = "1.0.40"
+portal-pc-waffle = "0.3.6"
 structopt = "0.3.21"
+waffle-unistub = "0.4.3"
 wasm-encoder = "0.212.0"
 wasmparser = "0.212.0"
 wizer = "6.0.0"

--- a/crates/wasi-vfs-cli/src/lib.rs
+++ b/crates/wasi-vfs-cli/src/lib.rs
@@ -103,7 +103,7 @@ pub fn pack(wasm_bytes: &[u8], map_dirs: Vec<(PathBuf, PathBuf)>, unishim: bool)
     //           and renames `__wasi_vfs_rt_init` to `_initialize`.
     //           And adds `__wasi_vfs_rt_init` as a new export duplicated from `_initialize`.
     // 3~n pack: Repeat the 2nd pack.
-    if is_wasi_reactor(wasm_bytes) {
+    if is_wasi_reactor(&wasm_bytes) {
         wizer.func_rename("_initialize", "__wasi_vfs_rt_init");
     }
     let output_bytes = wizer.run(&wasm_bytes)?;

--- a/src/trampoline_generated.rs
+++ b/src/trampoline_generated.rs
@@ -6,7 +6,7 @@ use crate::UserFd;
 use wasi::*;
 
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_advise"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_advise"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_advise(
     arg0: i32,
     arg1: i64,
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_advise(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_allocate"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_allocate"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_allocate(
     arg0: i32,
     arg1: i64,
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_allocate(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_close"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_close"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_close(arg0: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_close(fd: {})\n", arg0));
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_close(arg0: i32) -> 
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_datasync"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_datasync"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_datasync(arg0: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_datasync(fd: {})\n", arg0));
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_datasync(arg0: i32) 
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_fdstat_get"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_fdstat_get"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_get(
     arg0: i32,
     arg1: i32,
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_get(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_flags")
+    export_name("wasi_vfs.wasi_snapshot_preview1.fd_fdstat_set_flags")
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_flags(
     arg0: i32,
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_flags(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_rights")
+    export_name("wasi_vfs.wasi_snapshot_preview1.fd_fdstat_set_rights")
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_rights(
     arg0: i32,
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_rights(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_filestat_get"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_filestat_get"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_get(
     arg0: i32,
     arg1: i32,
@@ -262,7 +262,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_get(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_size")
+    export_name("wasi_vfs.wasi_snapshot_preview1.fd_filestat_set_size")
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_size(
     arg0: i32,
@@ -295,7 +295,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_size(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_times")
+    export_name("wasi_vfs.wasi_snapshot_preview1.fd_filestat_set_times")
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_times(
     arg0: i32,
@@ -334,7 +334,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_times(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_pread"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_pread"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pread(
     arg0: i32,
     arg1: i32,
@@ -373,7 +373,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pread(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_prestat_get"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_prestat_get"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_get(
     arg0: i32,
     arg1: i32,
@@ -403,7 +403,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_get(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs_wasi_snapshot_preview1_fd_prestat_dir_name")
+    export_name("wasi_vfs.wasi_snapshot_preview1.fd_prestat_dir_name")
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_dir_name(
     arg0: i32,
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_dir_name(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_pwrite"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_pwrite"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pwrite(
     arg0: i32,
     arg1: i32,
@@ -479,7 +479,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pwrite(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_read"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_read"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_read(
     arg0: i32,
     arg1: i32,
@@ -516,7 +516,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_read(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_readdir"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_readdir"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_readdir(
     arg0: i32,
     arg1: i32,
@@ -556,7 +556,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_readdir(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_renumber"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_renumber"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_renumber(arg0: i32, arg1: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_renumber(fd: {}, to: {})\n", arg0, arg1));
@@ -580,7 +580,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_renumber(arg0: i32, 
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_seek"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_seek"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_seek(
     arg0: i32,
     arg1: i64,
@@ -613,7 +613,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_seek(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_sync"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_sync"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_sync(arg0: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_sync(fd: {})\n", arg0));
@@ -637,7 +637,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_sync(arg0: i32) -> i
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_tell"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_tell"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_tell(arg0: i32, arg1: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_tell(fd: {})\n", arg0));
@@ -662,7 +662,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_tell(arg0: i32, arg1
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_write"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_write"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_write(
     arg0: i32,
     arg1: i32,
@@ -701,7 +701,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_write(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs_wasi_snapshot_preview1_path_create_directory")
+    export_name("wasi_vfs.wasi_snapshot_preview1.path_create_directory")
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_create_directory(
     arg0: i32,
@@ -743,7 +743,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_create_directory(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs_wasi_snapshot_preview1_path_filestat_get")
+    export_name("wasi_vfs.wasi_snapshot_preview1.path_filestat_get")
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_get(
     arg0: i32,
@@ -794,7 +794,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_get(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs_wasi_snapshot_preview1_path_filestat_set_times")
+    export_name("wasi_vfs.wasi_snapshot_preview1.path_filestat_set_times")
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_set_times(
     arg0: i32,
@@ -852,7 +852,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_set_times
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_link"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_link"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_link(
     arg0: i32,
     arg1: i32,
@@ -912,7 +912,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_link(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_open"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_open"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_open(
     arg0: i32,
     arg1: i32,
@@ -965,7 +965,7 @@ crate::trace::trace_syscall_entry(format_args!("path_open(fd: {}, dirflags: {}, 
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_readlink"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_readlink"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_readlink(
     arg0: i32,
     arg1: i32,
@@ -1018,7 +1018,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_readlink(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs_wasi_snapshot_preview1_path_remove_directory")
+    export_name("wasi_vfs.wasi_snapshot_preview1.path_remove_directory")
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_remove_directory(
     arg0: i32,
@@ -1058,7 +1058,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_remove_directory(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_rename"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_rename"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_rename(
     arg0: i32,
     arg1: i32,
@@ -1115,7 +1115,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_rename(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_symlink"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_symlink"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_symlink(
     arg0: i32,
     arg1: i32,
@@ -1169,7 +1169,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_symlink(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_unlink_file"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_unlink_file"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_unlink_file(
     arg0: i32,
     arg1: i32,
@@ -1208,7 +1208,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_unlink_file(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_poll_oneoff"))]
+#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.poll_oneoff"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_poll_oneoff(
     arg0: i32,
     arg1: i32,

--- a/src/trampoline_generated.rs
+++ b/src/trampoline_generated.rs
@@ -6,6 +6,7 @@ use crate::UserFd;
 use wasi::*;
 
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_advise"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_advise(
     arg0: i32,
     arg1: i64,
@@ -30,7 +31,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_advise(
             arg2 as u64,
             arg3,
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_advise", e.clone());
@@ -41,6 +44,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_advise(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_allocate"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_allocate(
     arg0: i32,
     arg1: i64,
@@ -63,7 +67,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_allocate(
             arg1 as u64,
             arg2 as u64,
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_allocate", e.clone());
@@ -74,6 +80,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_allocate(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_close"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_close(arg0: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_close(fd: {})\n", arg0));
@@ -84,7 +91,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_close(arg0: i32) -> 
     };
     {
         match crate::wasi_snapshot_preview1::fd_close(fs, arg0 as UserFd) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_close", e.clone());
@@ -95,6 +104,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_close(arg0: i32) -> 
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_datasync"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_datasync(arg0: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_datasync(fd: {})\n", arg0));
@@ -105,7 +115,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_datasync(arg0: i32) 
     };
     {
         match crate::wasi_snapshot_preview1::fd_datasync(fs, arg0 as UserFd) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_datasync", e.clone());
@@ -116,6 +128,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_datasync(arg0: i32) 
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_fdstat_get"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_get(
     arg0: i32,
     arg1: i32,
@@ -143,6 +156,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_get(
     }
 }
 #[no_mangle]
+#[cfg_attr(
+    cless,
+    export_name("wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_flags")
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_flags(
     arg0: i32,
     arg1: i32,
@@ -163,7 +180,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_flags(
             arg0 as UserFd,
             arg1 as Fdflags,
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_fdstat_set_flags", e.clone());
@@ -174,6 +193,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_flags(
     }
 }
 #[no_mangle]
+#[cfg_attr(
+    cless,
+    export_name("wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_rights")
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_rights(
     arg0: i32,
     arg1: i64,
@@ -196,7 +219,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_rights(
             arg1 as Rights,
             arg2 as Rights,
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_fdstat_set_rights", e.clone());
@@ -207,6 +232,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_rights(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_filestat_get"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_get(
     arg0: i32,
     arg1: i32,
@@ -234,6 +260,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_get(
     }
 }
 #[no_mangle]
+#[cfg_attr(
+    cless,
+    export_name("wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_size")
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_size(
     arg0: i32,
     arg1: i64,
@@ -250,7 +280,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_size(
     };
     {
         match crate::wasi_snapshot_preview1::fd_filestat_set_size(fs, arg0 as UserFd, arg1 as u64) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_filestat_set_size", e.clone());
@@ -261,6 +293,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_size(
     }
 }
 #[no_mangle]
+#[cfg_attr(
+    cless,
+    export_name("wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_times")
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_times(
     arg0: i32,
     arg1: i64,
@@ -285,7 +321,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_times(
             arg2 as u64,
             arg3 as Fstflags,
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_filestat_set_times", e.clone());
@@ -296,6 +334,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_times(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_pread"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pread(
     arg0: i32,
     arg1: i32,
@@ -334,6 +373,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pread(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_prestat_get"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_get(
     arg0: i32,
     arg1: i32,
@@ -361,6 +401,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_get(
     }
 }
 #[no_mangle]
+#[cfg_attr(
+    cless,
+    export_name("wasi_vfs_wasi_snapshot_preview1_fd_prestat_dir_name")
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_dir_name(
     arg0: i32,
     arg1: i32,
@@ -383,7 +427,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_dir_name(
             arg1 as *mut u8,
             arg2 as u32,
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_prestat_dir_name", e.clone());
@@ -394,6 +440,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_dir_name(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_pwrite"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pwrite(
     arg0: i32,
     arg1: i32,
@@ -432,6 +479,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pwrite(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_read"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_read(
     arg0: i32,
     arg1: i32,
@@ -468,6 +516,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_read(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_readdir"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_readdir(
     arg0: i32,
     arg1: i32,
@@ -507,6 +556,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_readdir(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_renumber"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_renumber(arg0: i32, arg1: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_renumber(fd: {}, to: {})\n", arg0, arg1));
@@ -517,7 +567,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_renumber(arg0: i32, 
     };
     {
         match crate::wasi_snapshot_preview1::fd_renumber(fs, arg0 as UserFd, arg1 as UserFd) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_renumber", e.clone());
@@ -528,6 +580,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_renumber(arg0: i32, 
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_seek"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_seek(
     arg0: i32,
     arg1: i64,
@@ -560,6 +613,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_seek(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_sync"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_sync(arg0: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_sync(fd: {})\n", arg0));
@@ -570,7 +624,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_sync(arg0: i32) -> i
     };
     {
         match crate::wasi_snapshot_preview1::fd_sync(fs, arg0 as UserFd) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("fd_sync", e.clone());
@@ -581,6 +637,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_sync(arg0: i32) -> i
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_tell"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_tell(arg0: i32, arg1: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_tell(fd: {})\n", arg0));
@@ -605,6 +662,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_tell(arg0: i32, arg1
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_fd_write"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_write(
     arg0: i32,
     arg1: i32,
@@ -641,6 +699,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_write(
     }
 }
 #[no_mangle]
+#[cfg_attr(
+    cless,
+    export_name("wasi_vfs_wasi_snapshot_preview1_path_create_directory")
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_create_directory(
     arg0: i32,
     arg1: i32,
@@ -666,7 +728,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_create_directory(
             let str_bytes = core::slice::from_raw_parts(arg1 as *const u8, (arg2 + 1) as usize);
             std::ffi::CStr::from_bytes_with_nul_unchecked(str_bytes)
         }) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("path_create_directory", e.clone());
@@ -677,6 +741,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_create_directory(
     }
 }
 #[no_mangle]
+#[cfg_attr(
+    cless,
+    export_name("wasi_vfs_wasi_snapshot_preview1_path_filestat_get")
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_get(
     arg0: i32,
     arg1: i32,
@@ -724,6 +792,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_get(
     }
 }
 #[no_mangle]
+#[cfg_attr(
+    cless,
+    export_name("wasi_vfs_wasi_snapshot_preview1_path_filestat_set_times")
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_set_times(
     arg0: i32,
     arg1: i32,
@@ -767,7 +839,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_set_times
             arg5 as u64,
             arg6 as Fstflags,
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("path_filestat_set_times", e.clone());
@@ -778,6 +852,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_set_times
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_link"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_link(
     arg0: i32,
     arg1: i32,
@@ -824,7 +899,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_link(
                 std::ffi::CStr::from_bytes_with_nul_unchecked(str_bytes)
             },
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("path_link", e.clone());
@@ -835,6 +912,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_link(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_open"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_open(
     arg0: i32,
     arg1: i32,
@@ -887,6 +965,7 @@ crate::trace::trace_syscall_entry(format_args!("path_open(fd: {}, dirflags: {}, 
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_readlink"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_readlink(
     arg0: i32,
     arg1: i32,
@@ -937,6 +1016,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_readlink(
     }
 }
 #[no_mangle]
+#[cfg_attr(
+    cless,
+    export_name("wasi_vfs_wasi_snapshot_preview1_path_remove_directory")
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_remove_directory(
     arg0: i32,
     arg1: i32,
@@ -962,7 +1045,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_remove_directory(
             let str_bytes = core::slice::from_raw_parts(arg1 as *const u8, (arg2 + 1) as usize);
             std::ffi::CStr::from_bytes_with_nul_unchecked(str_bytes)
         }) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("path_remove_directory", e.clone());
@@ -973,6 +1058,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_remove_directory(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_rename"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_rename(
     arg0: i32,
     arg1: i32,
@@ -1016,7 +1102,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_rename(
                 std::ffi::CStr::from_bytes_with_nul_unchecked(str_bytes)
             },
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("path_rename", e.clone());
@@ -1027,6 +1115,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_rename(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_symlink"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_symlink(
     arg0: i32,
     arg1: i32,
@@ -1067,7 +1156,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_symlink(
                 std::ffi::CStr::from_bytes_with_nul_unchecked(str_bytes)
             },
         ) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("path_symlink", e.clone());
@@ -1078,6 +1169,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_symlink(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_path_unlink_file"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_unlink_file(
     arg0: i32,
     arg1: i32,
@@ -1103,7 +1195,9 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_unlink_file(
             let str_bytes = core::slice::from_raw_parts(arg1 as *const u8, (arg2 + 1) as usize);
             std::ffi::CStr::from_bytes_with_nul_unchecked(str_bytes)
         }) {
-            Ok(e) => wasi::ERRNO_SUCCESS.raw() as i32,
+            Ok(e) => {
+                wasi::ERRNO_SUCCESS.raw() as i32
+            }
             Err(e) => {
                 #[cfg(feature = "trace-syscall")]
                 crate::trace::trace_syscall_error("path_unlink_file", e.clone());
@@ -1114,6 +1208,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_unlink_file(
     }
 }
 #[no_mangle]
+#[cfg_attr(cless, export_name("wasi_vfs_wasi_snapshot_preview1_poll_oneoff"))]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_poll_oneoff(
     arg0: i32,
     arg1: i32,

--- a/src/trampoline_generated.rs
+++ b/src/trampoline_generated.rs
@@ -6,7 +6,7 @@ use crate::UserFd;
 use wasi::*;
 
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_advise"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_advise")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_advise(
     arg0: i32,
     arg1: i64,
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_advise(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_allocate"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_allocate")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_allocate(
     arg0: i32,
     arg1: i64,
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_allocate(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_close"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_close")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_close(arg0: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_close(fd: {})\n", arg0));
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_close(arg0: i32) -> 
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_datasync"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_datasync")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_datasync(arg0: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_datasync(fd: {})\n", arg0));
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_datasync(arg0: i32) 
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_fdstat_get"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_fdstat_get")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_get(
     arg0: i32,
     arg1: i32,
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_get(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs.wasi_snapshot_preview1.fd_fdstat_set_flags")
+    export_name = "wasi_vfs.wasi_snapshot_preview1.fd_fdstat_set_flags"
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_flags(
     arg0: i32,
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_flags(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs.wasi_snapshot_preview1.fd_fdstat_set_rights")
+    export_name = "wasi_vfs.wasi_snapshot_preview1.fd_fdstat_set_rights"
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_rights(
     arg0: i32,
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_fdstat_set_rights(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_filestat_get"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_filestat_get")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_get(
     arg0: i32,
     arg1: i32,
@@ -262,7 +262,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_get(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs.wasi_snapshot_preview1.fd_filestat_set_size")
+    export_name = "wasi_vfs.wasi_snapshot_preview1.fd_filestat_set_size"
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_size(
     arg0: i32,
@@ -295,7 +295,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_size(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs.wasi_snapshot_preview1.fd_filestat_set_times")
+    export_name = "wasi_vfs.wasi_snapshot_preview1.fd_filestat_set_times"
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_times(
     arg0: i32,
@@ -334,7 +334,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_filestat_set_times(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_pread"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_pread")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pread(
     arg0: i32,
     arg1: i32,
@@ -373,7 +373,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pread(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_prestat_get"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_prestat_get")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_get(
     arg0: i32,
     arg1: i32,
@@ -403,7 +403,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_get(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs.wasi_snapshot_preview1.fd_prestat_dir_name")
+    export_name = "wasi_vfs.wasi_snapshot_preview1.fd_prestat_dir_name"
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_dir_name(
     arg0: i32,
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_prestat_dir_name(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_pwrite"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_pwrite")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pwrite(
     arg0: i32,
     arg1: i32,
@@ -479,7 +479,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_pwrite(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_read"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_read")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_read(
     arg0: i32,
     arg1: i32,
@@ -516,7 +516,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_read(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_readdir"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_readdir")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_readdir(
     arg0: i32,
     arg1: i32,
@@ -556,7 +556,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_readdir(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_renumber"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_renumber")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_renumber(arg0: i32, arg1: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_renumber(fd: {}, to: {})\n", arg0, arg1));
@@ -580,7 +580,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_renumber(arg0: i32, 
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_seek"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_seek")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_seek(
     arg0: i32,
     arg1: i64,
@@ -613,7 +613,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_seek(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_sync"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_sync")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_sync(arg0: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_sync(fd: {})\n", arg0));
@@ -637,7 +637,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_sync(arg0: i32) -> i
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_tell"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_tell")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_tell(arg0: i32, arg1: i32) -> i32 {
     #[cfg(feature = "trace-syscall")]
     crate::trace::trace_syscall_entry(format_args!("fd_tell(fd: {})\n", arg0));
@@ -662,7 +662,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_tell(arg0: i32, arg1
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.fd_write"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.fd_write")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_write(
     arg0: i32,
     arg1: i32,
@@ -701,7 +701,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_fd_write(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs.wasi_snapshot_preview1.path_create_directory")
+    export_name = "wasi_vfs.wasi_snapshot_preview1.path_create_directory"
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_create_directory(
     arg0: i32,
@@ -743,7 +743,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_create_directory(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs.wasi_snapshot_preview1.path_filestat_get")
+    export_name = "wasi_vfs.wasi_snapshot_preview1.path_filestat_get"
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_get(
     arg0: i32,
@@ -794,7 +794,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_get(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs.wasi_snapshot_preview1.path_filestat_set_times")
+    export_name = "wasi_vfs.wasi_snapshot_preview1.path_filestat_set_times"
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_set_times(
     arg0: i32,
@@ -852,7 +852,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_filestat_set_times
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_link"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.path_link")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_link(
     arg0: i32,
     arg1: i32,
@@ -912,7 +912,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_link(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_open"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.path_open")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_open(
     arg0: i32,
     arg1: i32,
@@ -965,7 +965,7 @@ crate::trace::trace_syscall_entry(format_args!("path_open(fd: {}, dirflags: {}, 
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_readlink"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.path_readlink")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_readlink(
     arg0: i32,
     arg1: i32,
@@ -1018,7 +1018,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_readlink(
 #[no_mangle]
 #[cfg_attr(
     cless,
-    export_name("wasi_vfs.wasi_snapshot_preview1.path_remove_directory")
+    export_name = "wasi_vfs.wasi_snapshot_preview1.path_remove_directory"
 )]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_remove_directory(
     arg0: i32,
@@ -1058,7 +1058,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_remove_directory(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_rename"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.path_rename")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_rename(
     arg0: i32,
     arg1: i32,
@@ -1115,7 +1115,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_rename(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_symlink"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.path_symlink")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_symlink(
     arg0: i32,
     arg1: i32,
@@ -1169,7 +1169,10 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_symlink(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.path_unlink_file"))]
+#[cfg_attr(
+    cless,
+    export_name = "wasi_vfs.wasi_snapshot_preview1.path_unlink_file"
+)]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_unlink_file(
     arg0: i32,
     arg1: i32,
@@ -1208,7 +1211,7 @@ pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_path_unlink_file(
     }
 }
 #[no_mangle]
-#[cfg_attr(cless, export_name("wasi_vfs.wasi_snapshot_preview1.poll_oneoff"))]
+#[cfg_attr(cless, export_name = "wasi_vfs.wasi_snapshot_preview1.poll_oneoff")]
 pub unsafe extern "C" fn wasi_vfs_wasi_snapshot_preview1_poll_oneoff(
     arg0: i32,
     arg1: i32,


### PR DESCRIPTION
THis adds a mode where syscalls are directly interposed, supporting native WASI Rust among other languages. This mode, however, requires further patching of the module to interpose syscalls, and requires changes to the build process, so, after this PR, GitHub actions would need to be updated. The old system is retained, and used by the artifacts made by the `Makefile` for backward compatibility.